### PR TITLE
Organizer User Stories, Firebase Integration, User Flow

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,14 @@
             </intent-filter>
         </activity>
         <activity android:name=".ListEventActivity" />
+        <activity android:name=".ManageEventsActivity" />
+        <activity android:name=".EntrantDetailsActivity" />
+        <activity android:name=".DisplayEventQrCodeActivity" />
+        <activity android:name=".UpdateEventActivity" />
+        <activity android:name=".MapViewActivity" />
+        <activity android:name=".CanceledEntrantsActivity" />
+        <activity android:name=".ChosenEntrantsActivity" />
+        <activity android:name=".WaitingListActivity" />
         <activity
             android:name=".RoleSelectionActivity"
             android:exported="false" />

--- a/app/src/main/java/com/example/frolic/CanceledEntrantsActivity.java
+++ b/app/src/main/java/com/example/frolic/CanceledEntrantsActivity.java
@@ -1,0 +1,67 @@
+package com.example.frolic;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+
+public class CanceledEntrantsActivity extends AppCompatActivity {
+
+    private TextView tvBack, tvTitle, tvCanceledListCount;
+    private RecyclerView rvEntrants;
+    private EntrantsAdapter adapter;
+    private ArrayList<String> canceledEntrantIds;
+
+    /**
+     * Called when the activity is first created. Sets up the RecyclerView, populates the
+     * list of canceled entrants, and configures the UI.
+     *
+     * @param savedInstanceState the state of the activity as previously saved
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.canceled_entrants_screen);
+
+        Intent intent = getIntent();
+        canceledEntrantIds = intent.getStringArrayListExtra("entrantList");
+
+        tvBack = findViewById(R.id.tvBack);
+        tvTitle = findViewById(R.id.tvTitle);
+        tvCanceledListCount = findViewById(R.id.llCanceled).findViewById(R.id.tvCount);
+        rvEntrants = findViewById(R.id.rvEntrants);
+
+        // Set up RecyclerView with EntrantsAdapter
+        rvEntrants.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new EntrantsAdapter(canceledEntrantIds);
+        rvEntrants.setAdapter(adapter);
+
+        // Update count
+        updateCountDisplay();
+
+        tvBack.setOnClickListener(v -> finish());
+
+        // Display a message if there are no entrants in the canceled list
+        if (canceledEntrantIds == null || canceledEntrantIds.isEmpty()) {
+            Toast.makeText(this, "No entrants in the canceled list.", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    /**
+     * Updates the count display with the number of entrants in the canceled list.
+     */
+    private void updateCountDisplay() {
+        if (canceledEntrantIds != null) {
+            tvCanceledListCount.setText(String.valueOf(canceledEntrantIds.size()));
+        } else {
+            tvCanceledListCount.setText("0");
+        }
+    }
+}

--- a/app/src/main/java/com/example/frolic/ChosenEntrantsActivity.java
+++ b/app/src/main/java/com/example/frolic/ChosenEntrantsActivity.java
@@ -1,0 +1,71 @@
+package com.example.frolic;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+
+/**
+ * ChosenEntrantsActivity displays a list of entrants who were selected in the lottery system
+ * for a specific event. It retrieves the list of chosen entrant IDs from the intent and displays
+ * each entrant's details in a RecyclerView. The count of chosen entrants is also dynamically
+ * displayed at the top of the screen.
+ */
+public class ChosenEntrantsActivity extends AppCompatActivity {
+
+    private TextView tvBack, tvTitle, tvChosenListCount;
+    private RecyclerView rvEntrants;
+    private EntrantsAdapter adapter;
+    private ArrayList<String> chosenEntrantIds;
+
+    /**
+     * Initializes the activity, sets up the UI components, retrieves the chosen entrant IDs from
+     * the intent, and displays them in a RecyclerView. Displays a message if no entrants are available.
+     *
+     * @param savedInstanceState the saved instance state for activity recreation
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.chosen_entrants_screen);
+
+        Intent intent = getIntent();
+        chosenEntrantIds = intent.getStringArrayListExtra("entrantList");
+
+        tvBack = findViewById(R.id.tvBack);
+        tvTitle = findViewById(R.id.tvTitle);
+        tvChosenListCount = findViewById(R.id.llChosenList).findViewById(R.id.tvCount);
+        rvEntrants = findViewById(R.id.rvEntrants);
+
+        rvEntrants.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new EntrantsAdapter(chosenEntrantIds);
+        rvEntrants.setAdapter(adapter);
+
+        updateCountDisplay();
+
+        tvBack.setOnClickListener(v -> finish());
+
+        if (chosenEntrantIds == null || chosenEntrantIds.isEmpty()) {
+            Toast.makeText(this, "No entrants in the chosen list.", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    /**
+     * Updates the count display of chosen entrants in the UI. Sets the text to "0" if
+     * the chosen entrant list is null.
+     */
+    private void updateCountDisplay() {
+        if (chosenEntrantIds != null) {
+            tvChosenListCount.setText(String.valueOf(chosenEntrantIds.size()));
+        } else {
+            tvChosenListCount.setText("0");
+        }
+    }
+}

--- a/app/src/main/java/com/example/frolic/DisplayEventQrCodeActivity.java
+++ b/app/src/main/java/com/example/frolic/DisplayEventQrCodeActivity.java
@@ -1,0 +1,112 @@
+package com.example.frolic;
+
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+/**
+ * DisplayEventQrCodeActivity retrieves a QR hash associated with an event from Firestore
+ * and generates a QR code based on this hash. The QR code is displayed on the screen and can
+ * be downloaded if needed. The activity includes a back button to return to the previous screen.
+ */
+public class DisplayEventQrCodeActivity extends AppCompatActivity {
+
+    private FirebaseFirestore db;
+    private String eventId;
+
+    /**
+     * Initializes the activity, sets up UI elements, and retrieves the QR code hash associated
+     * with the event ID provided in the intent. If the event ID is missing, the activity finishes
+     * with an error message.
+     *
+     * @param savedInstanceState the saved instance state for activity recreation
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.display_event_qr_code);
+
+        db = FirebaseFirestore.getInstance();
+        eventId = getIntent().getStringExtra("eventId");
+
+        // Retrieve QR Hash and generate the QR code
+        if (eventId != null) {
+            retrieveQrHashAndGenerateCode();
+        } else {
+            Toast.makeText(this, "Event ID is missing", Toast.LENGTH_SHORT).show();
+            finish();
+        }
+
+        Button btnDownloadQrCode = findViewById(R.id.btnDownloadQrCode);
+        btnDownloadQrCode.setOnClickListener(v -> downloadQrCode());
+
+        TextView tvBack = findViewById(R.id.tvBack);
+        tvBack.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                finish();
+            }
+        });
+    }
+
+    /**
+     * Queries Firestore to retrieve the `qrHash` for the event based on `eventId`,
+     * then generates and displays the QR code on the screen. If the event or QR hash is
+     * missing, an error message is shown.
+     */
+    private void retrieveQrHashAndGenerateCode() {
+        db.collection("events").document(eventId)
+                .get()
+                .addOnSuccessListener(documentSnapshot -> {
+                    if (documentSnapshot.exists()) {
+                        String qrHash = documentSnapshot.getString("qrHash");
+                        if (qrHash != null) {
+                            displayQrCode(qrHash);
+                        } else {
+                            Toast.makeText(this, "QR hash not found", Toast.LENGTH_SHORT).show();
+                        }
+                    } else {
+                        Toast.makeText(this, "Event not found", Toast.LENGTH_SHORT).show();
+                        finish();
+                    }
+                })
+                .addOnFailureListener(e -> {
+                    Toast.makeText(this, "Failed to retrieve QR hash", Toast.LENGTH_SHORT).show();
+                    e.printStackTrace();
+                });
+    }
+
+    /**
+     * Generates and displays the QR code image based on the provided QR hash. The QR code is
+     * displayed in the ImageView component on the screen. Shows an error message if QR code
+     * generation fails.
+     *
+     * @param qrHash the hash string to encode in the QR code
+     */
+    private void displayQrCode(String qrHash) {
+        Bitmap qrBitmap = QRCodeGenerator.generateQRCode(qrHash);
+        if (qrBitmap != null) {
+            ImageView ivQrCode = findViewById(R.id.ivQrCode);
+            ivQrCode.setImageBitmap(qrBitmap);
+        } else {
+            Toast.makeText(this, "Error generating QR code", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    /**
+     * Downloads the displayed QR code to the device's storage.
+     */
+    private void downloadQrCode() {
+        Toast.makeText(this, "Download functionality not yet implemented", Toast.LENGTH_SHORT).show();
+    }
+}

--- a/app/src/main/java/com/example/frolic/EntrantDetailsActivity.java
+++ b/app/src/main/java/com/example/frolic/EntrantDetailsActivity.java
@@ -1,0 +1,149 @@
+package com.example.frolic;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.PopupMenu;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import java.util.ArrayList;
+
+/**
+ * EntrantDetailsActivity displays details for an event's entrants, including counts for
+ * different entrant statuses (Waiting List, Chosen, Canceled) and a list of confirmed entrants.
+ * Users can filter entrants by status to view specific lists.
+ */
+public class EntrantDetailsActivity extends AppCompatActivity {
+
+    private TextView tvBack, tvFilter, tvWaitingListCount, tvChosenCount, tvCanceledCount;
+    private RecyclerView rvEntrants;
+    private EntrantsAdapter adapter;
+    private ArrayList<String> confirmedEntrantIds = new ArrayList<>();
+    private ArrayList<String> waitingListIds = new ArrayList<>();
+    private ArrayList<String> chosenListIds = new ArrayList<>();
+    private ArrayList<String> canceledListIds = new ArrayList<>();
+    private FirebaseFirestore db;
+    private String eventId;
+
+    /**
+     * Initializes the activity, setting up Firebase, retrieving event data from the intent, and
+     * configuring the UI elements and RecyclerView to display entrant details.
+     *
+     * @param savedInstanceState the saved instance state for activity recreation
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.entrant_details_screen);
+
+        db = FirebaseFirestore.getInstance();
+
+        eventId = getIntent().getStringExtra("eventId");
+
+        tvBack = findViewById(R.id.tvBack);
+        tvFilter = findViewById(R.id.tvFilter);
+        tvWaitingListCount = findViewById(R.id.tvWaitingListCount);
+        tvChosenCount = findViewById(R.id.tvChosenCount);
+        tvCanceledCount = findViewById(R.id.tvCanceledCount);
+        rvEntrants = findViewById(R.id.rvEntrants);
+
+        rvEntrants.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new EntrantsAdapter(confirmedEntrantIds); // Pass the list of entrant IDs
+        rvEntrants.setAdapter(adapter);
+
+        loadEntrantDetails();
+
+        TextView tvBack = findViewById(R.id.tvBack);
+        tvBack.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                finish();
+            }
+        });
+
+        // Set up filter dropdown
+        tvFilter.setOnClickListener(this::showFilterMenu);
+    }
+
+    /**
+     * Loads entrant details from Firestore for the current event, including entrant counts and IDs.
+     * Updates the UI with entrant counts and populates the RecyclerView with confirmed entrants.
+     */
+    private void loadEntrantDetails() {
+        db.collection("lotteries").document(eventId).get()
+                .addOnSuccessListener(documentSnapshot -> {
+                    if (documentSnapshot.exists()) {
+                        // Retrieve each list from Firestore document
+                        waitingListIds = (ArrayList<String>) documentSnapshot.get("waitingListIds");
+                        chosenListIds = (ArrayList<String>) documentSnapshot.get("invitedListIds");
+                        canceledListIds = (ArrayList<String>) documentSnapshot.get("canceledListIds");
+                        confirmedEntrantIds = (ArrayList<String>) documentSnapshot.get("confirmedListIds");
+
+                        // Update counts on the UI
+                        tvWaitingListCount.setText(String.valueOf(waitingListIds.size()));
+                        tvChosenCount.setText(String.valueOf(chosenListIds.size()));
+                        tvCanceledCount.setText(String.valueOf(canceledListIds.size()));
+
+                        // Load confirmed entrants into the RecyclerView
+                        adapter.updateEntrantsList(confirmedEntrantIds);
+                    }
+                })
+                .addOnFailureListener(e -> {
+                    Log.e("EntrantDetailsActivity", "Error loading lottery system data", e);
+                    Toast.makeText(this, "Error loading entrant details", Toast.LENGTH_SHORT).show();
+                });
+    }
+
+    /**
+     * Displays a filter menu allowing the user to filter entrants by status (Waiting List, Chosen, or Canceled).
+     *
+     * @param view the view that triggers the popup menu display
+     */
+    private void showFilterMenu(View view) {
+        PopupMenu popup = new PopupMenu(this, view);
+        popup.getMenuInflater().inflate(R.menu.entrant_list_filter_menu, popup.getMenu());
+        popup.setOnMenuItemClickListener(this::onFilterMenuItemClicked);
+        popup.show();
+    }
+
+    /**
+     * Handles the selection of a filter menu item by starting a new activity for the chosen list type.
+     *
+     * @param menuItem the selected menu item in the filter menu
+     * @return true if the menu item was successfully handled; false otherwise
+     */
+    private boolean onFilterMenuItemClicked(MenuItem menuItem) {
+        Intent intent;
+        int itemId = menuItem.getItemId();
+
+        if (itemId == R.id.filter_waiting_list) {
+            intent = new Intent(this, WaitingListActivity.class);
+            intent.putExtra("eventId", eventId);
+            intent.putStringArrayListExtra("entrantList", waitingListIds);
+            startActivity(intent);
+            return true;
+        } else if (itemId == R.id.filter_chosen) {
+            intent = new Intent(this, ChosenEntrantsActivity.class);
+            intent.putExtra("eventId", eventId);
+            intent.putStringArrayListExtra("entrantList", chosenListIds);
+            startActivity(intent);
+            return true;
+        } else if (itemId == R.id.filter_canceled) {
+            intent = new Intent(this, CanceledEntrantsActivity.class);
+            intent.putExtra("eventId", eventId);
+            intent.putStringArrayListExtra("entrantList", canceledListIds);
+            startActivity(intent);
+            return true;
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/com/example/frolic/EntrantsAdapter.java
+++ b/app/src/main/java/com/example/frolic/EntrantsAdapter.java
@@ -1,0 +1,121 @@
+package com.example.frolic;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.firestore.Source;
+import java.util.ArrayList;
+
+/**
+ * Adapter class for displaying entrant details in a RecyclerView. This adapter
+ * retrieves entrant information, including name and email, from Firestore using
+ * a list of entrant IDs.
+ * Used in the Organizer's view of entrants in their event
+ */
+public class EntrantsAdapter extends RecyclerView.Adapter<EntrantsAdapter.EntrantViewHolder> {
+
+    private ArrayList<String> entrantIds;
+    private FirebaseFirestore db;
+
+    /**
+     * Constructs an EntrantsAdapter with a list of entrant IDs.
+     * Initializes a Firebase Firestore instance for fetching entrant details.
+     *
+     * @param entrantIds List of entrant IDs used to query Firestore for entrant details
+     */
+    public EntrantsAdapter(ArrayList<String> entrantIds) {
+        this.entrantIds = entrantIds;
+        this.db = FirebaseFirestore.getInstance();
+    }
+
+    /**
+     * Inflates the layout for each item in the RecyclerView.
+     *
+     * @param parent The parent view group
+     * @param viewType The view type of the new View
+     * @return A new instance of EntrantViewHolder containing the inflated view
+     */
+    @NonNull
+    @Override
+    public EntrantViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_entrant, parent, false);
+        return new EntrantViewHolder(view);
+    }
+
+    /**
+     * Binds the entrant data from Firestore to the ViewHolder. Fetches entrant name and email
+     * based on entrant ID, and updates the TextViews in the ViewHolder. Handles cases where
+     * entrant data is missing or fetch fails.
+     *
+     * @param holder The ViewHolder containing views to bind the data
+     * @param position The position of the item within the adapter's data set
+     */
+    @Override
+    public void onBindViewHolder(@NonNull EntrantViewHolder holder, int position) {
+        String entrantId = entrantIds.get(position);
+
+        // Fetch entrant details from Firebase based on entrantId
+        DocumentReference entrantRef = db.collection("entrants").document(entrantId);
+        entrantRef.get(Source.SERVER).addOnSuccessListener(documentSnapshot -> {
+            if (documentSnapshot.exists()) {
+                // Set the name and email on the TextViews
+                holder.tvEntrantName.setText(documentSnapshot.getString("name"));
+                holder.tvEntrantEmail.setText(documentSnapshot.getString("email"));
+            } else {
+                // If no data found, set default text
+                holder.tvEntrantName.setText("Unknown");
+                holder.tvEntrantEmail.setText("No email available");
+            }
+        }).addOnFailureListener(e -> {
+            // Handle any errors
+            holder.tvEntrantName.setText("Error loading");
+            holder.tvEntrantEmail.setText("Error loading email");
+        });
+    }
+
+    /**
+     * Returns the total number of entrant IDs in the list.
+     *
+     * @return Size of the entrant IDs list
+     */
+    @Override
+    public int getItemCount() {
+        return entrantIds.size();
+    }
+
+    /**
+     * Updates the list of entrant IDs used in the adapter and refreshes the RecyclerView.
+     *
+     * @param newEntrantsList New list of entrant IDs
+     */
+    public void updateEntrantsList(ArrayList<String> newEntrantsList) {
+        this.entrantIds.clear();
+        this.entrantIds.addAll(newEntrantsList);
+        notifyDataSetChanged();
+    }
+
+    /**
+     * ViewHolder class for managing individual entrant views within the RecyclerView.
+     * Holds references to the name and email TextViews.
+     */
+    public static class EntrantViewHolder extends RecyclerView.ViewHolder {
+        TextView tvEntrantName, tvEntrantEmail;
+
+        /**
+         * Initializes TextView references for entrant name and email.
+         *
+         * @param itemView The view of the individual list item
+         */
+        public EntrantViewHolder(@NonNull View itemView) {
+            super(itemView);
+            tvEntrantName = itemView.findViewById(R.id.tvEntrantName);
+            tvEntrantEmail = itemView.findViewById(R.id.tvEntrantEmail);
+        }
+    }
+}

--- a/app/src/main/java/com/example/frolic/LotterySystem.java
+++ b/app/src/main/java/com/example/frolic/LotterySystem.java
@@ -1,43 +1,54 @@
 package com.example.frolic;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import android.util.Log;
 
-import com.google.firebase.firestore.auth.User;
-
 public class LotterySystem {
-    private Event event;
-    private ArrayList<Entrant> waitingList;
-    private ArrayList<Entrant> invitedList;
-    private ArrayList<Entrant> confirmedList;
+    private String lotterySystemId;
+    private String eventId;
+    private ArrayList<String> waitingListIds = new ArrayList<>();
+    private ArrayList<String> invitedListIds = new ArrayList<>();
+    private ArrayList<String> confirmedListIds = new ArrayList<>();
+    private ArrayList<String> canceledListIds = new ArrayList<>();
     private int maxAttendees;
     private int maxWaiting;
 
     // TODO: Add Javadocs
 
-    public LotterySystem() {
-        waitingList = new ArrayList<Entrant>();
-        invitedList = new ArrayList<Entrant>();
-        confirmedList = new ArrayList<Entrant>();
+    /**
+     * Constructs a LotterySystem with the specified event and capacity limits.
+     *
+     * @param lotterySystemId the unique identifier for this lottery system
+     * @param eventId         the unique identifier for the associated event
+     * @param maxAttendees    the maximum number of attendees for the event
+     * @param maxWaiting      the maximum number of entrants allowed on the waitlist
+     */
+    public LotterySystem(String lotterySystemId, String eventId, int maxAttendees, int maxWaiting) {
+        this.lotterySystemId = lotterySystemId;
+        this.eventId = eventId;
+        this.maxAttendees = maxAttendees;
+        this.maxWaiting = maxWaiting;
     }
 
-    public LotterySystem(Event event) {
-        this.event = event;
-        this.maxAttendees = event.getMaxConfirmed();
-        this.maxWaiting = event.getWaitlistLimit();
-        waitingList = new ArrayList<Entrant>();
-        invitedList = new ArrayList<Entrant>();
-        confirmedList = new ArrayList<Entrant>();
-    }
+    /**
+     * Randomly selects entrants from the waiting list and moves them to the invited list.
+     *
+     * @return a list of entrant IDs that have been invited to the event
+     */
+    public ArrayList<String> drawLottery() {
+        Collections.shuffle(waitingListIds);
+        int drawLimit = Math.min(waitingListIds.size(), maxAttendees);
 
-    public ArrayList<Entrant> drawLottery() {
-        Collections.shuffle(waitingList);
-        for (int i = 0; i < Math.min(waitingList.size(), maxAttendees); i++) {
-            invitedList.add(waitingList.get(i));
+        for (int i = 0; i < drawLimit; i++) {
+            invitedListIds.add(waitingListIds.get(i));
         }
-        waitingList.removeAll(invitedList);
-        return invitedList;
+
+        // Remove invited entrants from waiting list
+        waitingListIds.removeAll(invitedListIds);
+        return invitedListIds;
     }
 
     // TODO: Add method that notifies users when they've been drawn for the lottery
@@ -45,13 +56,13 @@ public class LotterySystem {
     /**
      * Adds an entrant to the event's waiting list if the maximum capacity has not been reached.
      *
-     * @param entrant the entrant to be added to the waiting list
+     * @param entrantId the id of the entrant to be added to the waiting list
      * @return {@code true} if the entrant was successfully added to the waiting list;
      *         {@code false} if the waiting list has reached its maximum capacity
      */
-    public boolean addToWaitingList(Entrant entrant) {
-        if (maxWaiting == -1 || waitingList.size() < maxWaiting) {
-            return waitingList.add(entrant);
+    public boolean addToWaitingList(String entrantId) {
+        if (maxWaiting == -1 || waitingListIds.size() < maxWaiting) {
+            return waitingListIds.add(entrantId);
         } else {
             Log.e("LotterySystem", "Waiting list is full. Entrant could not be added.");
             return false;
@@ -61,35 +72,59 @@ public class LotterySystem {
     /**
      * Removes an entrant from the event's waiting list if they exist on the list.
      *
-     * @param entrant the entrant to be removed from the waiting list
+     * @param entrantId the id of the entrant to be removed from the waiting list
      * @return {@code true} if the entrant was successfully removed;
      *         {@code false} if the entrant was not found in the waiting list
      * @throws AssertionError if the entrant is not in the waiting list,
      *                        logs an error indicating the removal attempt for a non-existent entrant
      */
-    public boolean removeFromWaitingList(Entrant entrant) {
-        try { assert waitingList.contains(entrant); }
+    public boolean removeFromWaitingList(String entrantId) {
+        try { assert waitingListIds.contains(entrantId); }
         catch (AssertionError e) { Log.e("LotterySystem.java", "Tried to remove a user that doesn't exist form the waiting list", e); }
-        return waitingList.remove(entrant);
+        return waitingListIds.remove(entrantId);
     }
 
-    public ArrayList<Entrant> getWaitingList() {
-        return waitingList;
+    /**
+     * Converts this LotterySystem object to a map representation for Firebase storage.
+     *
+     * @return a map containing the lottery system's attributes and their values
+     */
+    public Map<String, Object> toMap() {
+        Map<String, Object> lotteryMap = new HashMap<>();
+        lotteryMap.put("lotterySystemId", lotterySystemId);
+        lotteryMap.put("eventId", eventId);
+        lotteryMap.put("waitingListIds", waitingListIds);
+        lotteryMap.put("invitedListIds", invitedListIds);
+        lotteryMap.put("confirmedListIds", confirmedListIds);
+        lotteryMap.put("canceledListIds", canceledListIds);
+        lotteryMap.put("maxAttendees", maxAttendees);
+        lotteryMap.put("maxWaiting", maxWaiting);
+        return lotteryMap;
     }
 
-    public void setWaitingList(ArrayList<Entrant> waitingList) {
-        this.waitingList = waitingList;
+    public ArrayList<String> getWaitingListIds() {
+        return waitingListIds;
     }
 
-
-    public ArrayList<Entrant> getConfirmedList() {
-        return confirmedList;
+    public ArrayList<String> getInvitedListIds() {
+        return invitedListIds;
     }
 
-    public void setConfirmedList(ArrayList<Entrant> confirmedList) {
-        this.confirmedList = confirmedList;
+    public ArrayList<String> getConfirmedListIds() {
+        return confirmedListIds;
     }
 
+    public ArrayList<String> getCanceledListIds() {
+        return canceledListIds;
+    }
+
+    public String getEventId() {
+        return eventId;
+    }
+
+    public String getLotterySystemId() {
+        return lotterySystemId;
+    }
 
     public int getMaxAttendees() {
         return maxAttendees;
@@ -99,5 +134,11 @@ public class LotterySystem {
         this.maxAttendees = maxAttendees;
     }
 
+    public int getMaxWaiting() {
+        return maxWaiting;
+    }
 
+    public void setMaxWaiting(int maxWaiting) {
+        this.maxWaiting = maxWaiting;
+    }
 }

--- a/app/src/main/java/com/example/frolic/ManageEventsActivity.java
+++ b/app/src/main/java/com/example/frolic/ManageEventsActivity.java
@@ -1,0 +1,91 @@
+package com.example.frolic;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.firebase.firestore.DocumentSnapshot;
+import com.google.firebase.firestore.FirebaseFirestore;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Activity for managing and displaying a list of events organized by the user
+ * in a RecyclerView with details fetched from Firebase Firestore.
+ * Allows for options to view entrant details, update the event, view event QR code,
+ * view map where users join from if geolocation option for event was enabled
+ */
+public class ManageEventsActivity extends AppCompatActivity {
+
+    private FirebaseFirestore db;
+    private RecyclerView rvEvents;
+    private ManageEventsAdapter adapter;
+    private List<Event> eventList = new ArrayList<>();
+    private String organizerId;
+
+    /**
+     * Initializes the activity, sets up the RecyclerView for displaying events,
+     * and loads events organized by the specified organizer.
+     *
+     * @param savedInstanceState Bundle containing the activity's previously saved state.
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_manage_events);
+
+        db = FirebaseFirestore.getInstance();
+
+        organizerId = getIntent().getStringExtra("deviceId");
+
+        rvEvents = findViewById(R.id.rvEvents);
+        rvEvents.setLayoutManager(new LinearLayoutManager(this));
+
+        adapter = new ManageEventsAdapter(this, eventList);
+        rvEvents.setAdapter(adapter);  // Attach the adapter to the RecyclerView
+
+        loadEvents();
+
+        TextView tvBackManageEvents = findViewById(R.id.tvBackManageEvents);
+        tvBackManageEvents.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                // Navigate back to OrganizerDashboardActivity
+                Intent intent = new Intent(ManageEventsActivity.this, OrganizerDashboardActivity.class);
+                intent.putExtra("deviceId", organizerId);
+                startActivity(intent);
+                finish();
+            }
+        });
+    }
+
+    /**
+     * Loads events for the specified organizer from Firestore and updates the RecyclerView.
+     * Clears the existing event list and fetches current data from Firestore.
+     */
+    private void loadEvents() {
+        db.collection("events")
+                .whereEqualTo("organizerId", organizerId)
+                .get()
+                .addOnSuccessListener(queryDocumentSnapshots -> {
+                    eventList.clear();
+                    for (DocumentSnapshot doc : queryDocumentSnapshots) {
+                        Event event = doc.toObject(Event.class);
+                        eventList.add(event);
+                    }
+                    adapter = new ManageEventsAdapter(this, eventList);
+                    rvEvents.setAdapter(adapter);
+                })
+                .addOnFailureListener(e -> {
+                    Toast.makeText(this, "Failed to load events", Toast.LENGTH_SHORT).show();
+                });
+    }
+}
+

--- a/app/src/main/java/com/example/frolic/ManageEventsAdapter.java
+++ b/app/src/main/java/com/example/frolic/ManageEventsAdapter.java
@@ -1,0 +1,145 @@
+package com.example.frolic;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * Adapter for managing and displaying a list of events in the RecyclerView for the ManageEventsActivity.
+ * Each event includes options to view entrants, update the event, view a QR code, and view a map if geolocation is enabled.
+ */
+public class ManageEventsAdapter extends RecyclerView.Adapter<ManageEventsAdapter.EventViewHolder> {
+
+    private List<Event> eventList;
+    private Context context;
+
+    /**
+     * Constructs a new ManageEventsAdapter with the given context and list of events.
+     *
+     * @param context   The activity context for managing intents and resource access.
+     * @param eventList A list of Event objects to be displayed in the RecyclerView.
+     */
+    public ManageEventsAdapter(Context context, List<Event> eventList) {
+        this.context = context;
+        this.eventList = eventList;
+    }
+
+    /**
+     * Inflates the view for each event item in the RecyclerView.
+     *
+     * @param parent   The ViewGroup into which the new view will be added after it is bound to an adapter position.
+     * @param viewType The view type of the new view.
+     * @return A new instance of EventViewHolder containing the inflated view.
+     */
+    @NonNull
+    @Override
+    public EventViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        View view = LayoutInflater.from(context).inflate(R.layout.organizers_list_of_events, parent, false);
+        return new EventViewHolder(view);
+    }
+
+    /**
+     * Binds data to each item in the RecyclerView. Displays event details and provides options for viewing entrants,
+     * updating the event, viewing the QR code, and viewing the map if geolocation is enabled.
+     *
+     * @param holder   The ViewHolder that holds the item view.
+     * @param position The position of the item in the data set.
+     */
+    @Override
+    public void onBindViewHolder(@NonNull EventViewHolder holder, int position) {
+        Event event = eventList.get(position);
+        holder.tvEventName.setText(event.getEventName());
+
+        SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, MMMM d yyyy", Locale.getDefault());
+        String formattedDate = dateFormat.format(event.getEventDate());
+        holder.tvEventDate.setText(formattedDate);
+
+        // View Entrants
+        holder.iconViewEntrants.setOnClickListener(v -> {
+            Intent intent = new Intent(context, EntrantDetailsActivity.class);
+            intent.putExtra("eventId", event.getEventId());
+            context.startActivity(intent);
+        });
+
+        // Update Event
+        holder.iconUpdateEvent.setOnClickListener(v -> {
+            Intent intent = new Intent(context, UpdateEventActivity.class);
+            intent.putExtra("eventId", event.getEventId());
+            context.startActivity(intent);
+        });
+
+        // View QR Code
+        holder.iconViewQRCode.setOnClickListener(v -> {
+            Intent intent = new Intent(context, DisplayEventQrCodeActivity.class);
+            intent.putExtra("eventId", event.getEventId());
+            context.startActivity(intent);
+        });
+
+        // Only show Map icon if geolocation is required
+        if (event.isGeolocationRequired()) {
+            holder.iconViewMap.setVisibility(View.VISIBLE);
+            holder.iconMapLabel.setVisibility(View.VISIBLE);
+            holder.iconViewMap.setOnClickListener(v -> {
+                Intent intent = new Intent(context, MapViewActivity.class);
+                intent.putExtra("eventId", event.getEventId());
+                context.startActivity(intent);
+            });
+        } else {
+            holder.iconViewMap.setVisibility(View.GONE);
+            holder.iconMapLabel.setVisibility(View.GONE);
+        }
+    }
+
+    /**
+     * Returns the total number of events in the list.
+     *
+     * @return The size of the event list.
+     */
+    @Override
+    public int getItemCount() {
+        return eventList.size();
+    }
+
+    /**
+     * ViewHolder class to hold references to each item view's elements, such as event name, date,
+     * and icons for viewing entrants, updating events, viewing QR codes, and viewing maps.
+     */
+    public static class EventViewHolder extends RecyclerView.ViewHolder {
+        TextView tvEventName, tvEventDate;
+        ImageView iconViewEntrants, iconUpdateEvent, iconViewQRCode, iconViewMap;
+        TextView iconEntrantsLabel, iconUpdateLabel, iconQRCodeLabel, iconMapLabel;
+
+        /**
+         * Initializes the view holder for event items, finding each view by ID.
+         *
+         * @param itemView The individual item view layout for each event.
+         */
+        public EventViewHolder(@NonNull View itemView) {
+            super(itemView);
+            tvEventName = itemView.findViewById(R.id.tvEventName);
+            tvEventDate = itemView.findViewById(R.id.tvEventDate);
+            iconViewEntrants = itemView.findViewById(R.id.iconViewEntrants);
+            iconUpdateEvent = itemView.findViewById(R.id.iconUpdateEvent);
+            iconViewQRCode = itemView.findViewById(R.id.iconViewQRCode);
+            iconViewMap = itemView.findViewById(R.id.iconViewMap);
+
+            // Label TextViews for each icon (need to find by id for visibility control on Map)
+            iconEntrantsLabel = itemView.findViewById(R.id.iconEntrantsLabel);
+            iconUpdateLabel = itemView.findViewById(R.id.iconUpdateLabel);
+            iconQRCodeLabel = itemView.findViewById(R.id.iconQRCodeLabel);
+            iconMapLabel = itemView.findViewById(R.id.iconMapLabel);
+        }
+    }
+}

--- a/app/src/main/java/com/example/frolic/MapViewActivity.java
+++ b/app/src/main/java/com/example/frolic/MapViewActivity.java
@@ -1,0 +1,39 @@
+package com.example.frolic;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+/**
+ * Activity to display a map view related to a specific event. Allows users to view the map
+ * associated with an event and includes a back button to return to the previous screen.
+ */
+public class MapViewActivity extends AppCompatActivity {
+
+    private String eventId;
+
+    /**
+     * Called when the activity is first created. Initializes the view, retrieves the event ID
+     * from the intent, and sets up the back button functionality.
+     *
+     * @param savedInstanceState If the activity is being re-initialized after previously being shut down,
+     *                           this Bundle contains the data it most recently supplied. Otherwise, it is null.
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.view_of_map_screen);
+
+        eventId = getIntent().getStringExtra("eventId");
+
+        TextView tvBack = findViewById(R.id.tvBack);
+        tvBack.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                finish();
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/example/frolic/OrganizerEditProfile.java
+++ b/app/src/main/java/com/example/frolic/OrganizerEditProfile.java
@@ -28,6 +28,7 @@ import com.google.firebase.firestore.FirebaseFirestore;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -302,11 +303,25 @@ public class OrganizerEditProfile extends AppCompatActivity {
         userData.put("role", "ORGANIZER");
         userData.put("facilityId", facilityId);
 
-        if (selectedImageUri != null) {
-            handleImageInFirestore(userData);
-        } else {
-            saveToFirestore(userData);
-        }
+        db.collection("organizers").document(deviceId)
+                .get()
+                .addOnSuccessListener(document -> {
+                    if (!document.exists() || !document.contains("eventsOrganizing")) {
+                        // Initialize `eventsOrganizing` as an empty list only if it doesn’t exist
+                        userData.put("eventsOrganizing", new ArrayList<>());
+                    }
+
+                    // Add image processing if a new image is selected
+                    if (selectedImageUri != null) {
+                        handleImageInFirestore(userData);
+                    } else {
+                        saveToFirestore(userData);
+                    }
+                })
+                .addOnFailureListener(e -> {
+                    Log.e(TAG, "Error checking if eventsOrganizing exists", e);
+                    Toast.makeText(this, "Error saving profile", Toast.LENGTH_SHORT).show();
+                });
     }
 
     /**

--- a/app/src/main/java/com/example/frolic/UpdateEventActivity.java
+++ b/app/src/main/java/com/example/frolic/UpdateEventActivity.java
@@ -1,0 +1,30 @@
+package com.example.frolic;
+
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+// TODO: Needs to be implemented. Need to ask TA about what is allowed to be updated
+// in an event. In the user stories it only mentions the event poster.
+public class UpdateEventActivity extends AppCompatActivity {
+
+    private String eventId;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.event_info_screen);
+
+        // Retrieve eventId from intent
+        eventId = getIntent().getStringExtra("eventId");
+
+        TextView tvBack = findViewById(R.id.tvBack);
+        tvBack.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                finish();
+            }
+        });
+    }
+}

--- a/app/src/main/java/com/example/frolic/WaitingListActivity.java
+++ b/app/src/main/java/com/example/frolic/WaitingListActivity.java
@@ -1,0 +1,71 @@
+package com.example.frolic;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+
+/**
+ * Activity to display the waiting list of entrants for an event.
+ * Shows the list of entrants who are on the waiting list, with a count
+ * of total entrants. Allows navigation back to the previous screen.
+ */
+public class WaitingListActivity extends AppCompatActivity {
+
+    private TextView tvBack, tvTitle, tvWaitingListCount;
+    private RecyclerView rvEntrants;
+    private EntrantsAdapter adapter;
+    private ArrayList<String> waitingListEntrantIds;
+
+    /**
+     * Initializes the activity, retrieves the list of waiting entrants from the intent,
+     * sets up the views, and configures the RecyclerView to display the list of waiting entrants.
+     *
+     * @param savedInstanceState If the activity is being re-initialized after previously being shut down,
+     *                           this Bundle contains the data it most recently supplied. Otherwise, it is null.
+     */
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.waiting_list_screen);
+
+        Intent intent = getIntent();
+        waitingListEntrantIds = intent.getStringArrayListExtra("entrantList");
+
+        tvBack = findViewById(R.id.tvBack);
+        tvTitle = findViewById(R.id.tvTitle);
+        tvWaitingListCount = findViewById(R.id.llWaitingList).findViewById(R.id.tvCount);
+        rvEntrants = findViewById(R.id.rvEntrants);
+
+        rvEntrants.setLayoutManager(new LinearLayoutManager(this));
+        adapter = new EntrantsAdapter(waitingListEntrantIds);
+        rvEntrants.setAdapter(adapter);
+
+        updateCountDisplay();
+
+        tvBack.setOnClickListener(v -> finish());
+
+        if (waitingListEntrantIds == null || waitingListEntrantIds.isEmpty()) {
+            Toast.makeText(this, "No entrants in the waiting list.", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    /**
+     * Updates the display of the waiting list count based on the size of waitingListEntrantIds.
+     * Sets the count to 0 if the list is null or empty.
+     */
+    private void updateCountDisplay() {
+        if (waitingListEntrantIds != null) {
+            tvWaitingListCount.setText(String.valueOf(waitingListEntrantIds.size()));
+        } else {
+            tvWaitingListCount.setText("0");
+        }
+    }
+}

--- a/app/src/main/res/drawable/baseline_person_24.xml
+++ b/app/src/main/res/drawable/baseline_person_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M12,12c2.21,0 4,-1.79 4,-4s-1.79,-4 -4,-4 -4,1.79 -4,4 1.79,4 4,4zM12,14c-2.67,0 -8,1.34 -8,4v2h16v-2c0,-2.66 -5.33,-4 -8,-4z"/>
+    
+</vector>

--- a/app/src/main/res/drawable/baseline_qr_code_2_24.xml
+++ b/app/src/main/res/drawable/baseline_qr_code_2_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M15,21h-2v-2h2V21zM13,14h-2v5h2V14zM21,12h-2v4h2V12zM19,10h-2v2h2V10zM7,12H5v2h2V12zM5,10H3v2h2V10zM12,5h2V3h-2V5zM4.5,4.5v3h3v-3H4.5zM9,9H3V3h6V9zM4.5,16.5v3h3v-3H4.5zM9,21H3v-6h6V21zM16.5,4.5v3h3v-3H16.5zM21,9h-6V3h6V9zM19,19v-3l-4,0v2h2v3h4v-2H19zM17,12l-4,0v2h4V12zM13,10H7v2h2v2h2v-2h2V10zM14,9V7h-2V5h-2v4L14,9zM6.75,5.25h-1.5v1.5h1.5V5.25zM6.75,17.25h-1.5v1.5h1.5V17.25zM18.75,5.25h-1.5v1.5h1.5V5.25z"/>
+    
+</vector>

--- a/app/src/main/res/layout/activity_manage_events.xml
+++ b/app/src/main/res/layout/activity_manage_events.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#F2F2F2"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/tvBackManageEvents"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Back"
+        android:textColor="#5DB075"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginEnd="8dp" />
+
+    <TextView
+        android:id="@+id/tvManageEventsTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Manage Events"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:textColor="@android:color/black"
+        android:textStyle="bold"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toEndOf="@id/tvBackManageEvents"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rvEvents"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:scrollbars="vertical"
+        app:layout_constraintTop_toBottomOf="@id/tvManageEventsTitle"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginTop="16dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/canceled_entrants_screen.xml
+++ b/app/src/main/res/layout/canceled_entrants_screen.xml
@@ -19,7 +19,7 @@
         android:id="@+id/tvTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Picked Entrants"
+        android:text="Canceled Entrants"
         android:textSize="20sp"
         android:textStyle="bold"
         android:textColor="@android:color/black"
@@ -28,56 +28,37 @@
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="16dp" />
 
-    <TextView
-        android:id="@+id/tvFilter"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Filter"
-        android:textColor="#5DB075"
-        android:layout_margin="16dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
     <LinearLayout
-        android:id="@+id/llStatus"
+        android:id="@+id/llCanceled"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal"
+        android:orientation="vertical"
         android:background="#FFF0E0"
-        android:padding="8dp"
+        android:padding="16dp"
         app:layout_constraintTop_toBottomOf="@id/tvTitle"
         android:layout_marginTop="16dp">
 
         <TextView
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="Accepted\n00"
-            android:textAlignment="center"
+            android:text="Entrants who canceled"
             android:textColor="#FF9800" />
 
         <TextView
-            android:layout_width="0dp"
+            android:id="@+id/tvCount"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="Rejected\n00"
-            android:textAlignment="center"
-            android:textColor="#FF9800" />
-
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="Notified\n00"
-            android:textAlignment="center"
-            android:textColor="#FF9800" />
+            android:text="00"
+            android:textColor="#FF9800"
+            android:textStyle="bold"
+            android:textSize="18sp" />
     </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rvEntrants"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/llStatus"
+        app:layout_constraintTop_toBottomOf="@id/llCanceled"
         app:layout_constraintBottom_toTopOf="@id/btnNotifyAllEntrants"
         android:layout_marginTop="16dp"
         android:layout_marginBottom="16dp" />

--- a/app/src/main/res/layout/chosen_entrants_screen.xml
+++ b/app/src/main/res/layout/chosen_entrants_screen.xml
@@ -19,7 +19,7 @@
         android:id="@+id/tvTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Waiting List"
+        android:text="Chosen List"
         android:textSize="20sp"
         android:textStyle="bold"
         android:textColor="@android:color/black"
@@ -29,7 +29,7 @@
         android:layout_marginTop="16dp" />
 
     <LinearLayout
-        android:id="@+id/llWaitingList"
+        android:id="@+id/llChosenList"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
@@ -41,7 +41,7 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Waiting List"
+            android:text="Entrants Chosen In The Lottery"
             android:textColor="#FF9800" />
 
         <TextView
@@ -58,7 +58,7 @@
         android:id="@+id/rvEntrants"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/llWaitingList"
+        app:layout_constraintTop_toBottomOf="@id/llChosenList"
         app:layout_constraintBottom_toTopOf="@id/btnNotifyAllEntrants"
         android:layout_marginTop="16dp"
         android:layout_marginBottom="16dp" />

--- a/app/src/main/res/layout/display_event_qr_code.xml
+++ b/app/src/main/res/layout/display_event_qr_code.xml
@@ -19,7 +19,7 @@
         android:id="@+id/tvTitle"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Not Picked Entrants"
+        android:text="Your QR Code"
         android:textSize="20sp"
         android:textStyle="bold"
         android:textColor="@android:color/black"
@@ -28,49 +28,27 @@
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="16dp" />
 
-    <LinearLayout
-        android:id="@+id/llNotified"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:background="#FFF0E0"
-        android:padding="16dp"
-        app:layout_constraintTop_toBottomOf="@id/tvTitle"
-        android:layout_marginTop="16dp">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="Notified"
-            android:textColor="#FF9800" />
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="00"
-            android:textColor="#FF9800"
-            android:textStyle="bold"
-            android:textSize="18sp" />
-    </LinearLayout>
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/rvEntrants"
-        android:layout_width="match_parent"
+    <ImageView
+        android:id="@+id/ivQrCode"
+        android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintTop_toBottomOf="@id/llNotified"
-        app:layout_constraintBottom_toTopOf="@id/btnNotifyAllEntrants"
-        android:layout_marginTop="16dp"
-        android:layout_marginBottom="16dp" />
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="16dp"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle"
+        app:layout_constraintBottom_toTopOf="@id/btnDownloadQrCode"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:contentDescription="QR Code Image"
+        android:scaleType="fitCenter" />
 
     <Button
-        android:id="@+id/btnNotifyAllEntrants"
+        android:id="@+id/btnDownloadQrCode"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:text="Notify All Entrants"
+        android:text="Download QR Code"
         android:backgroundTint="#5DB075"
         android:textColor="@android:color/white"
-        android:layout_marginHorizontal="24dp"
-        android:layout_marginBottom="24dp"
+        android:layout_margin="24dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />

--- a/app/src/main/res/layout/entrant_details_screen.xml
+++ b/app/src/main/res/layout/entrant_details_screen.xml
@@ -39,6 +39,7 @@
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
+    <!-- Updated LinearLayout with labels and counts -->
     <LinearLayout
         android:id="@+id/llStatus"
         android:layout_width="match_parent"
@@ -49,29 +50,80 @@
         app:layout_constraintTop_toBottomOf="@id/tvTitle"
         android:layout_marginTop="16dp">
 
-        <TextView
+        <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="Waiting List\n00"
-            android:textAlignment="center"
-            android:textColor="#FF9800" />
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
 
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:text="Picked\n00"
-            android:textAlignment="center"
-            android:textColor="#FF9800" />
+            <TextView
+                android:id="@+id/tvWaitingListLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Waiting List"
+                android:textColor="#FF9800"
+                android:textStyle="bold"
+                android:textAlignment="center" />
 
-        <TextView
+            <TextView
+                android:id="@+id/tvWaitingListCount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="00"
+                android:textAlignment="center"
+                android:textColor="#FF9800" />
+        </LinearLayout>
+
+        <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:text="Not Picked\n00"
-            android:textAlignment="center"
-            android:textColor="#FF9800" />
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
+
+            <TextView
+                android:id="@+id/tvChosenLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Chosen"
+                android:textColor="#FF9800"
+                android:textStyle="bold"
+                android:textAlignment="center" />
+
+            <TextView
+                android:id="@+id/tvChosenCount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="00"
+                android:textAlignment="center"
+                android:textColor="#FF9800" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical"
+            android:gravity="center_horizontal">
+
+            <TextView
+                android:id="@+id/tvCanceledLabel"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Canceled"
+                android:textColor="#FF9800"
+                android:textStyle="bold"
+                android:textAlignment="center" />
+
+            <TextView
+                android:id="@+id/tvCanceledCount"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="00"
+                android:textAlignment="center"
+                android:textColor="#FF9800" />
+        </LinearLayout>
 
     </LinearLayout>
 
@@ -114,11 +166,12 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="24dp"
+        android:layout_marginBottom="16dp"
         android:backgroundTint="#5DB075"
         android:text="Notify All Entrants"
         android:textColor="@android:color/white"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        tools:layout_editor_absoluteY="659dp" />
+        app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/event_info_screen.xml
+++ b/app/src/main/res/layout/event_info_screen.xml
@@ -5,11 +5,12 @@
     android:layout_height="match_parent"
     android:background="@android:color/white">
 
-    <ImageView
-        android:id="@+id/ivClose"
+    <TextView
+        android:id="@+id/tvBack"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:src="@android:drawable/ic_menu_add"
+        android:text="Back"
+        android:textColor="#5DB075"
         android:layout_margin="16dp"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintStart_toStartOf="parent" />
@@ -101,20 +102,6 @@
         app:layout_constraintEnd_toEndOf="parent" />
 
     <EditText
-        android:id="@+id/etPrice"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:hint="Price"
-        android:inputType="numberDecimal"
-        android:layout_marginHorizontal="24dp"
-        android:layout_marginTop="16dp"
-        android:padding="12dp"
-        android:background="@android:color/darker_gray"
-        app:layout_constraintTop_toBottomOf="@id/etVacancy"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-    <EditText
         android:id="@+id/etWaitlistLimit"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -124,7 +111,7 @@
         android:layout_marginTop="16dp"
         android:padding="12dp"
         android:background="@android:color/darker_gray"
-        app:layout_constraintTop_toBottomOf="@id/etPrice"
+        app:layout_constraintTop_toBottomOf="@id/etVacancy"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/layout/item_entrant.xml
+++ b/app/src/main/res/layout/item_entrant.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/tvEntrantName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Name"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        android:textColor="@android:color/black"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/tvEntrantEmail"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="email@example.com"
+        android:textSize="14sp"
+        android:textColor="@android:color/black"
+        app:layout_constraintTop_toBottomOf="@id/tvEntrantName"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/list_event_screen.xml
+++ b/app/src/main/res/layout/list_event_screen.xml
@@ -28,16 +28,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         android:layout_marginTop="16dp" />
 
-    <TextView
-        android:id="@+id/tvLogin"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Login"
-        android:textColor="#5DB075"
-        android:layout_margin="16dp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
     <ImageView
         android:id="@+id/ivAddImage"
         android:layout_width="48dp"
@@ -102,20 +92,6 @@
         app:layout_constraintEnd_toEndOf="parent" />
 
     <EditText
-        android:id="@+id/etPrice"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:hint="Price"
-        android:inputType="numberDecimal"
-        android:layout_marginHorizontal="24dp"
-        android:layout_marginTop="16dp"
-        android:padding="12dp"
-        android:background="@android:color/darker_gray"
-        app:layout_constraintTop_toBottomOf="@id/etVacancy"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
-
-    <EditText
         android:id="@+id/etWaitlistLimit"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -125,7 +101,7 @@
         android:layout_marginTop="16dp"
         android:padding="12dp"
         android:background="@android:color/darker_gray"
-        app:layout_constraintTop_toBottomOf="@id/etPrice"
+        app:layout_constraintTop_toBottomOf="@id/etVacancy"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 

--- a/app/src/main/res/layout/organizer_dashboard_screen.xml
+++ b/app/src/main/res/layout/organizer_dashboard_screen.xml
@@ -45,15 +45,6 @@
             android:layout_marginTop="8dp" />
 
         <TextView
-            android:id="@+id/tvViewEntrants"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="View Entrants"
-            android:background="@android:color/darker_gray"
-            android:padding="16dp"
-            android:layout_marginTop="8dp" />
-
-        <TextView
             android:id="@+id/tvNotifications"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -63,10 +54,10 @@
             android:layout_marginTop="8dp" />
 
         <TextView
-            android:id="@+id/tvFacilitiesProfile"
+            android:id="@+id/tvMyProfile"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Facilities Profile"
+            android:text="My Profile"
             android:background="@android:color/darker_gray"
             android:padding="16dp"
             android:layout_marginTop="8dp" />

--- a/app/src/main/res/layout/organizers_list_of_events.xml
+++ b/app/src/main/res/layout/organizers_list_of_events.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    android:background="#FFFFFF"
+    android:elevation="4dp"
+    android:padding="16dp"
+    android:radius="12dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <!-- Event Name and Date -->
+        <TextView
+            android:id="@+id/tvEventName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:textColor="#000000"
+            android:text="Event Name" />
+
+        <TextView
+            android:id="@+id/tvEventDate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="14sp"
+            android:textColor="#666666"
+            android:paddingTop="4dp"
+            android:text="Event Date" />
+
+        <!-- Icon Row for Event Actions -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_horizontal"
+            android:paddingTop="12dp"
+            android:paddingBottom="8dp"
+            android:weightSum="4">
+
+            <!-- Entrants Icon -->
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="8dp"
+                android:layout_weight="1">
+
+                <ImageView
+                    android:id="@+id/iconViewEntrants"
+                    android:layout_width="28dp"
+                    android:layout_height="28dp"
+                    android:src="@drawable/baseline_person_24"
+                    app:tint="#333333" />
+
+                <TextView
+                    android:id="@+id/iconEntrantsLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Entrants"
+                    android:textSize="12sp"
+                    android:textColor="#333333"
+                    android:paddingTop="4dp" />
+            </LinearLayout>
+
+            <!-- Update Icon -->
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="8dp"
+                android:layout_weight="1">
+
+                <ImageView
+                    android:id="@+id/iconUpdateEvent"
+                    android:layout_width="28dp"
+                    android:layout_height="28dp"
+                    android:src="@android:drawable/ic_menu_edit"
+                    app:tint="#333333" />
+
+                <TextView
+                    android:id="@+id/iconUpdateLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Update"
+                    android:textSize="12sp"
+                    android:textColor="#333333"
+                    android:paddingTop="4dp" />
+            </LinearLayout>
+
+            <!-- QR Code Icon -->
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="8dp"
+                android:layout_weight="1">
+
+                <ImageView
+                    android:id="@+id/iconViewQRCode"
+                    android:layout_width="28dp"
+                    android:layout_height="28dp"
+                    android:src="@drawable/baseline_qr_code_2_24"
+                    app:tint="#333333" />
+
+                <TextView
+                    android:id="@+id/iconQRCodeLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="QR Code"
+                    android:textSize="12sp"
+                    android:textColor="#333333"
+                    android:paddingTop="4dp" />
+            </LinearLayout>
+
+            <!-- Map Icon -->
+            <LinearLayout
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="8dp"
+                android:layout_weight="1">
+
+                <ImageView
+                    android:id="@+id/iconViewMap"
+                    android:layout_width="28dp"
+                    android:layout_height="28dp"
+                    android:src="@android:drawable/ic_menu_mapmode"
+                    android:visibility="gone"
+                    app:tint="#333333" />
+
+                <TextView
+                    android:id="@+id/iconMapLabel"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Map"
+                    android:textSize="12sp"
+                    android:textColor="#333333"
+                    android:paddingTop="4dp"
+                    android:visibility="gone"/>
+            </LinearLayout>
+        </LinearLayout>
+    </LinearLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/view_of_map_screen.xml
+++ b/app/src/main/res/layout/view_of_map_screen.xml
@@ -5,6 +5,16 @@
     android:layout_height="match_parent"
     android:background="#5DB075">
 
+    <TextView
+        android:id="@+id/tvBack"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Back"
+        android:textColor="#5DB075"
+        android:layout_margin="16dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
     <androidx.cardview.widget.CardView
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -46,21 +56,6 @@
                 android:src="@android:drawable/ic_menu_add"
                 android:scaleType="fitCenter"
                 android:layout_marginBottom="16dp"/>
-
-            <androidx.appcompat.widget.SwitchCompat
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Enable/Disable Geolocations"
-                android:background="#F0F0F0"
-                android:padding="8dp"
-                android:layout_marginBottom="16dp"/>
-
-            <Button
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Update Changes"
-                android:backgroundTint="#5DB075"
-                android:textColor="@android:color/white"/>
 
         </LinearLayout>
 

--- a/app/src/main/res/menu/entrant_list_filter_menu.xml
+++ b/app/src/main/res/menu/entrant_list_filter_menu.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/filter_waiting_list"
+        android:title="Waiting List" />
+    <item
+        android:id="@+id/filter_chosen"
+        android:title="Chosen Entrants" />
+    <item
+        android:id="@+id/filter_canceled"
+        android:title="Canceled Entrants" />
+</menu>


### PR DESCRIPTION
Created lots of intents in the organizer dashboard so an Organizer can now create an event, update their profile, see all of their events through Manage Events, and from there a user can see the entrant details, update page for the event, view their QR code, and view the map. I changed the UI a bit for this, but I think it feels pretty intuitive now. We can refine it of course in a later stage. 

The creation of an Event now also creates a corresponding lottery system and adds the Event into the Organizers array of Events. Everything is connected in Firebase. I had to tweak the Lottery class to use Ids instead of direct objects and I added some arrays that were missing. 

Implemented user stories: US 02.02.01, US 02.06.01, US 02.06.02, US 02.06.03, which allow the Organizer to view all the different types of lists of their entrants. This can be seen in Organizer Dashboard->Manage Events->Select Event-> Entrants-> Then you can filter the list.

fixes #19 fixes #24 fixes #13 fixes #12 fixes #50 